### PR TITLE
Adding QuixBugs.

### DIFF
--- a/data/benchmarks.json
+++ b/data/benchmarks.json
@@ -36,5 +36,13 @@
 	"repo": "https://github.com/rjust/defects4j",
 	"target": "Java",
 	"dblp": "conf/issta/JustJE14"
+    },
+    {
+	"name": "QuixBugs",
+	"description": "A parallel corpus of 40 programs in both Python and Java, each with a bug on one line",
+	"url": "https://jkoppel.github.io/QuixBugs/",
+	"repo": "https://github.com/jkoppel/QuixBugs",
+	"target": "Java and Python",
+	"dblp": "conf/q/JustJE14"
     }
 ]


### PR DESCRIPTION
Poster paper presented at SPLASH 2017. For some reason, the papers from the SPLASH '17 companion have not yet appeared on DBLP.