### PR TITLE
Add tool "HIPPODROME"

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -341,5 +341,13 @@
 	"repo": "https://github.com/squaresLab/genprog-code",
 	"target": "C/C++",
 	"dblp": "conf/icse/GouesDFW12"
+    },
+    {
+	"name": "HIPPODROME",
+	"description": "statically detects and fixes data race conditions for small to large scale Java programs",
+	"url": " https://github.com/verse-lab/hippodrome",
+	"repo": " https://github.com/verse-lab/hippodrome",
+	"target": "Java",
+	"dblp": "journals/corr/abs-2108-02490"
     }
 ]


### PR DESCRIPTION
I would like to add the following tool:

- Name: HIPPODROME
- One line description: statically detects and fixes data race conditions for small to large scale Java programs
- Target: Java
- DBPL key: journals/corr/abs-2108-02490
- Website: https://github.com/verse-lab/hippodrome
- Repository (optional): https://github.com/verse-lab/hippodrome