### PR TITLE
Adding paper "HIPPODROME: Data Race Repair using Static Analysis Summaries"

### DIFF
--- a/data/bibliography.csv
+++ b/data/bibliography.csv
@@ -338,3 +338,4 @@ conf/gpce/Weimer06,
 conf/cav/JobstmannGB05,
 conf/charme/StaberJB05,
 journals/ubiquity/MonperrusUDMBS19,
+journals/corr/abs-2108-02490


### PR DESCRIPTION
I would like to add the following publication:

- DBLP key: journals/corr/abs-2108-02490