### PR TITLE
Adding tool "NEM"

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -341,5 +341,13 @@
 	"repo": "https://github.com/squaresLab/genprog-code",
 	"target": "C/C++",
 	"dblp": "conf/icse/GouesDFW12"
+    },
+    {
+	"name": "NEM",
+	"description": "automated repair of heap-manipulating programs using deductive synthesis",
+	"url": "https://nem-repair-tool.github.io/",
+	"repo": "https://github.com/nem-repair-tool/heap-repair",
+	"target": "C/C++",
+	"dblp": "conf/vmcai/NguyenTSC21"
     }
 ]


### PR DESCRIPTION
I would like to add the following tool:

- Name: NEM
- One line description: automated repair of heap-manipulating programs using deductive synthesis
- Target: C/C++
- DBPL key: conf/vmcai/NguyenTSC21
- Website: https://nem-repair-tool.github.io/
- Repository (optional): https://github.com/nem-repair-tool/heap-repair