### PR TITLE
Changing the name of Defects4C++ to Bugs-C++

### DIFF
--- a/benchmarks.html
+++ b/benchmarks.html
@@ -99,6 +99,15 @@
 	</tr>
 	<tr class="spaceUnder">
 	  <th style="vertical-align:top" width="10%">
+	    <a href="https://github.com/Suresoft-GLaDOS/bugscpp"><i class="fas fa-code-branch" aria-hidden="true"></i></a>
+	    	    
+	  </th>
+	  <td style="vertical-align:top">
+	    <a id="Bugs-C++ (pronounced Bugsy)" href="https://github.com/Suresoft-GLaDOS/bugscpp">Bugs-C++ (pronounced Bugsy)</a> &mdash; A dockerized benchmark/infrastructure for C/C++ defects providing easy-to-use interfaces similar to Defects4J
+	  </td>
+	</tr>
+	<tr class="spaceUnder">
+	  <th style="vertical-align:top" width="10%">
 	    <a href="bibliography.html#journals_corr_abs-2206-08768"><i class="fas fa-book" aria-hidden="true"></i></a>
 	    <a href="https://github.com/pmorvalho/C-Pack-IPAs"><i class="fas fa-code-branch" aria-hidden="true"></i></a>
 	    	    
@@ -125,15 +134,6 @@
 	  </th>
 	  <td style="vertical-align:top">
 	    <a id="DBGBench" href="https://dbgbench.github.io">DBGBench</a> &mdash; 291 (in)correct patches from real software professionals for 27 real bugs in C for the qualitative evaluation of automated repair techniques
-	  </td>
-	</tr>
-	<tr class="spaceUnder">
-	  <th style="vertical-align:top" width="10%">
-	    <a href="https://github.com/Suresoft-GLaDOS/defects4cpp"><i class="fas fa-code-branch" aria-hidden="true"></i></a>
-	    	    
-	  </th>
-	  <td style="vertical-align:top">
-	    <a id="Defects4Cpp" href="https://github.com/Suresoft-GLaDOS/defects4cpp">Defects4Cpp</a> &mdash; A benchmark/infrastructure for C/C++ defects providing easy-to-use interfaces similar to Defects4J
 	  </td>
 	</tr>
 	<tr class="spaceUnder">

--- a/data/benchmarks.json
+++ b/data/benchmarks.json
@@ -85,7 +85,7 @@
 	"repo": "https://github.com/bugs-dot-jar/bugs-dot-jar",
 	"target": "Java",
 	"dblp": "conf/msr/SahaLLYP18"
-    },    
+    },
     {
 	"name": "QuixBugs",
 	"description": "a parallel corpus of 40 programs in both Python and Java, each with a bug on one line",
@@ -103,12 +103,12 @@
 	"repo": "https://github.com/dbgbench/dbgbench.github.io"
     },
     {
-	"name": "Defects4Cpp",
-	"description": "A benchmark/infrastructure for C/C++ defects providing easy-to-use interfaces similar to Defects4J",
-	"url": "https://github.com/Suresoft-GLaDOS/defects4cpp",
-	"target": "C/C++",
-	"repo": "https://github.com/Suresoft-GLaDOS/defects4cpp"
-    },    
+		"name": "Bugs-C++ (pronounced Bugsy)",
+		"description": "A dockerized benchmark/infrastructure for C/C++ defects providing easy-to-use interfaces similar to Defects4J",
+		"url": "https://github.com/Suresoft-GLaDOS/bugscpp",
+		"target": "C/C++",
+		"repo": "https://github.com/Suresoft-GLaDOS/bugscpp"
+    },
     {
 	"name": "Codeflaws",
 	"description": "3902 bugs from Codeforces programming competition for evaluating program repair tools across different defect classes",


### PR DESCRIPTION
We would like to change the name of Defects4C++ to Bugs-C++.